### PR TITLE
Fix Travis build by removing Node.js 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
   - 8
-  - 7
 after_script: 'cat ./coverage/lcov.info | coveralls'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Installation
 
-First, install [Yeoman](http://yeoman.io) and generator-awesome-webpack-starter using [npm](https://www.npmjs.com/) (we assume you have pre-installed [node.js](https://nodejs.org/)).
+First, install [Yeoman](http://yeoman.io) and generator-awesome-webpack-starter using [npm](https://www.npmjs.com/) (we assume you have pre-installed [node.js](https://nodejs.org/) v8.0.0+).
 
 ```bash
 npm install -g yo


### PR DESCRIPTION
Fixes #29 

`yeoman-generator` depends on the npm package `read-pkg-up` which uses `async/await` syntax unsupported by Node versions earlier than v8.0.0, which is why the Node 7 build is failing and Node 8 build succeeds. 

Using Node 7 with `nvm`:

```
  console.error node_modules/jest-cli/node_modules/jest-jasmine2/build/jasmine/Env.js:157
    Unhandled error

  console.error node_modules/jest-cli/node_modules/jest-jasmine2/build/jasmine/Env.js:158
    /Users/mvasigh/repositories/generator-awesome-webpack-starter/node_modules/yeoman-generator/node_modules/read-pkg-up/index.js:6
    module.exports = async options => {
                           ^^^^^^^
    SyntaxError: Unexpected identifier
        at ScriptTransformer._transformAndBuildScript (/Users/mvasigh/repositories/generator-awesome-webpack-starter/node_modules/jest-runner/node_modules/jest-runtime/build/script_transformer.js:403:17)
        at ScriptTransformer.transform (/Users/mvasigh/repositories/generator-awesome-webpack-starter/node_modules/jest-runner/node_modules/jest-runtime/build/script_transformer.js:448:19)
        at Runtime._execModule (/Users/mvasigh/repositories/generator-awesome-webpack-starter/node_modules/jest-runner/node_modules/jest-runtime/build/index.js:640:53)
        at Runtime.requireModule (/Users/mvasigh/repositories/generator-awesome-webpack-starter/node_modules/jest-runner/node_modules/jest-runtime/build/index.js:376:14)
        at Runtime.requireModuleOrMock (/Users/mvasigh/repositories/generator-awesome-webpack-starter/node_modules/jest-runner/node_modules/jest-runtime/build/index.js:463:19)
        at Object.<anonymous> (/Users/mvasigh/repositories/generator-awesome-webpack-starter/node_modules/yeoman-generator/lib/index.js:9:19)
        at Runtime._execModule (/Users/mvasigh/repositories/generator-awesome-webpack-starter/node_modules/jest-runner/node_modules/jest-runtime/build/index.js:694:13)
        at Runtime.requireModule (/Users/mvasigh/repositories/generator-awesome-webpack-starter/node_modules/jest-runner/node_modules/jest-runtime/build/index.js:376:14)
        at Runtime.requireModuleOrMock (/Users/mvasigh/repositories/generator-awesome-webpack-starter/node_modules/jest-runner/node_modules/jest-runtime/build/index.js:463:19)
        at Object.require (/Users/mvasigh/repositories/generator-awesome-webpack-starter/generators/app/index.js:2:19)

 FAIL  __tests__/app.js (6.226s)
  generator-awesome-webpack-starter:app
    ✕ creates files (18ms)

  ● generator-awesome-webpack-starter:app › creates files
```

Using Node 8:
```
 PASS  __tests__/app.js
  generator-awesome-webpack-starter:app
    ✓ creates files (1ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1.434s, estimated 7s
Ran all test suites.
```